### PR TITLE
GetColliding without any allocations

### DIFF
--- a/Scripts/BoundsOctreeNode.cs
+++ b/Scripts/BoundsOctreeNode.cs
@@ -127,28 +127,25 @@ public class BoundsOctreeNode<T> {
 	/// </summary>
 	/// <param name="checkBounds">Bounds to check.</param>
 	/// <returns>Objects that intersect with the specified bounds.</returns>
-	public T[] GetColliding(Bounds checkBounds) {
-		List<T> collidingWith = new List<T>();
+	public void GetColliding(ref Bounds checkBounds, List<T> result) {
 		// Are the input bounds at least partially in this node?
 		if (!bounds.Intersects(checkBounds)) {
-			return collidingWith.ToArray();
+			return;
 		}
 
 		// Check against any objects in this node
 		for (int i = 0; i < objects.Count; i++) {
 			if (objects[i].Bounds.Intersects(checkBounds)) {
-				collidingWith.Add(objects[i].Obj);
+				result.Add(objects[i].Obj);
 			}
 		}
 
 		// Check children
 		if (children != null) {
 			for (int i = 0; i < 8; i++) {
-				T[] childColliding = children[i].GetColliding(checkBounds);
-				if (childColliding != null) collidingWith.AddRange(childColliding);
+				children[i].GetColliding(ref checkBounds, result);
 			}
 		}
-		return collidingWith.ToArray();
 	}
 
 	/// <summary>


### PR DESCRIPTION
Will need more work, the things that call this will need updating too.

Passing Bounds as a ref should be a very small performance gain.
Doing no allocations in this function should help lots with GC pressure.

http://answers.unity3d.com/questions/739015/structs-passed-by-ref-better-performance.html
