### PR TITLE
Avoid unity's equals overload

### DIFF
--- a/Scripts/PointOctreeNode.cs
+++ b/Scripts/PointOctreeNode.cs
@@ -66,7 +66,7 @@ public class PointOctreeNode<T> where T : class {
 		bool removed = false;
 
 		for (int i = 0; i < objects.Count; i++) {
-			if (objects[i].Obj.Equals(obj)) {
+			if ((object)(objects[i].Obj) == obj) {
 				removed = objects.Remove(objects[i]);
 				break;
 			}


### PR DESCRIPTION
Casting to object first for comparison avoids unity's expensive equality calls and the overhead of an extra method call.

Unity does some weird stuff on the C++ side(for example, using this for null checks only reliably works in a compiled build), so this may need additional testing beyond the small amount I did.