### PR TITLE
Remove(T, Vector3) and GetNearby(Vector3, float)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ There are two octree implementations here:
 **A few functions are implemented:**
 
 With BoundsOctree, you can pass in bounds and get a true/false answer for if it's colliding with anything (IsColliding), or get a list of everything it's collising with (GetColliding).
-With PointOctree, you can cast a ray and get a list of objects that are within x distance of that ray (GetNearby).
+With PointOctree, you can cast a ray and get a list of objects that are within x distance of that ray (GetNearby). You may also get a list of objects that are within x distance from a specified origin point.
 
 It shouldn't be too hard to implement additional functions if needed. For instance, PointOctree could check for points that fall inside a given bounds.
 
@@ -78,6 +78,11 @@ pointTree.GetNearby(myRay, 4);
 ```
 - Where myRay is a [Ray](http://docs.unity3d.com/Documentation/ScriptReference/Ray.html)
 - In this case we're looking for any point within 4m of the closest point on the ray
+
+```C#
+pointTree.GetNearby(myPos, 4);
+```
+- Where myPos is a [Vector3](http://docs.unity3d.com/Documentation/ScriptReference/Vector3.html)
 
 **Debugging Visuals**
 

--- a/Scripts/BoundsOctree.cs
+++ b/Scripts/BoundsOctree.cs
@@ -24,14 +24,17 @@ using UnityEngine;
 public class BoundsOctree<T> {
 	// The total amount of objects currently in the tree
 	public int Count { get; private set; }
-	
+
 	// Root node of the octree
 	BoundsOctreeNode<T> rootNode;
+
 	// Should be a value between 1 and 2. A multiplier for the base size of a node.
 	// 1.0 is a "normal" octree, while values > 1 have overlap
 	readonly float looseness;
+
 	// Size that the octree was on creation
 	readonly float initialSize;
+
 	// Minimum side length that a node can be - essentially an alternative to having a max depth
 	readonly float minSize;
 	// For collision visualisation. Automatically removed in builds.
@@ -97,13 +100,13 @@ public class BoundsOctree<T> {
 		return removed;
 	}
 
-    /// <summary>
-    /// Removes the specified object at the given position. Makes the assumption that the object only exists once in the tree.
-    /// </summary>
-    /// <param name="obj">Object to remove.</param>
-    /// <param name="objBounds">3D bounding box around the object.</param>
-    /// <returns>True if the object was removed successfully.</returns>
-    public bool Remove(T obj, Bounds objBounds) {
+	/// <summary>
+	/// Removes the specified object at the given position. Makes the assumption that the object only exists once in the tree.
+	/// </summary>
+	/// <param name="obj">Object to remove.</param>
+	/// <param name="objBounds">3D bounding box around the object.</param>
+	/// <returns>True if the object was removed successfully.</returns>
+	public bool Remove(T obj, Bounds objBounds) {
 		bool removed = rootNode.Remove(obj, objBounds);
 
 		// See if we can shrink the octree down now that we've removed the item
@@ -171,8 +174,7 @@ public class BoundsOctree<T> {
 		rootNode.GetColliding(ref checkRay, collidingWith, maxDistance);
 	}
 
-	public Bounds GetMaxBounds()
-	{
+	public Bounds GetMaxBounds() {
 		return rootNode.GetBounds();
 	}
 
@@ -262,19 +264,15 @@ public class BoundsOctree<T> {
 		// Create a new, bigger octree root node
 		rootNode = new BoundsOctreeNode<T>(newLength, minSize, looseness, newCenter);
 
-		if (oldRoot.HasAnyObjects())
-		{
+		if (oldRoot.HasAnyObjects()) {
 			// Create 7 new octree children to go with the old root as children of the new root
 			int rootPos = GetRootPosIndex(xDirection, yDirection, zDirection);
 			BoundsOctreeNode<T>[] children = new BoundsOctreeNode<T>[8];
-			for (int i = 0; i < 8; i++)
-			{
-				if (i == rootPos)
-				{
+			for (int i = 0; i < 8; i++) {
+				if (i == rootPos) {
 					children[i] = oldRoot;
 				}
-				else
-				{
+				else {
 					xDirection = i % 2 == 0 ? -1 : 1;
 					yDirection = i > 3 ? -1 : 1;
 					zDirection = (i < 2 || (i > 3 && i < 6)) ? -1 : 1;

--- a/Scripts/BoundsOctree.cs
+++ b/Scripts/BoundsOctree.cs
@@ -97,6 +97,24 @@ public class BoundsOctree<T> {
 		return removed;
 	}
 
+    /// <summary>
+    /// Removes the specified object at the given position. Makes the assumption that the object only exists once in the tree.
+    /// </summary>
+    /// <param name="obj">Object to remove.</param>
+    /// <param name="objBounds">3D bounding box around the object.</param>
+    /// <returns>True if the object was removed successfully.</returns>
+    public bool Remove(T obj, Bounds objBounds) {
+		bool removed = rootNode.Remove(obj, objBounds);
+
+		// See if we can shrink the octree down now that we've removed the item
+		if (removed) {
+			Count--;
+			Shrink();
+		}
+
+		return removed;
+	}
+
 	/// <summary>
 	/// Check if the specified bounds intersect with anything in the tree. See also: GetColliding.
 	/// </summary>

--- a/Scripts/BoundsOctreeNode.cs
+++ b/Scripts/BoundsOctreeNode.cs
@@ -6,23 +6,31 @@ using UnityEngine;
 public class BoundsOctreeNode<T> {
 	// Centre of this node
 	public Vector3 Center { get; private set; }
+
 	// Length of this node if it has a looseness of 1.0
 	public float BaseLength { get; private set; }
 
 	// Looseness value for this node
 	float looseness;
+
 	// Minimum size for a node in this octree
 	float minSize;
+
 	// Actual length of sides, taking the looseness value into account
 	float adjLength;
+
 	// Bounding box that represents this node
 	Bounds bounds = default(Bounds);
+
 	// Objects in this node
 	readonly List<OctreeObject> objects = new List<OctreeObject>();
+
 	// Child nodes, if any
 	BoundsOctreeNode<T>[] children = null;
+
 	// Bounds of potential children to this node. These are actual size (with looseness taken into account), not base size
 	Bounds[] childBounds;
+
 	// If there are already numObjectsAllowed in a node, we split it into children
 	// A generally good number seems to be something around 8-15
 	const int numObjectsAllowed = 8;
@@ -92,18 +100,18 @@ public class BoundsOctreeNode<T> {
 		return removed;
 	}
 
-    /// <summary>
-    /// Removes the specified object at the given position. Makes the assumption that the object only exists once in the tree.
-    /// </summary>
-    /// <param name="obj">Object to remove.</param>
-    /// <param name="objBounds">3D bounding box around the object.</param>
-    /// <returns>True if the object was removed successfully.</returns>
-    public bool Remove(T obj, Bounds objBounds) {
-        if (!Encapsulates(bounds, objBounds)) {
+	/// <summary>
+	/// Removes the specified object at the given position. Makes the assumption that the object only exists once in the tree.
+	/// </summary>
+	/// <param name="obj">Object to remove.</param>
+	/// <param name="objBounds">3D bounding box around the object.</param>
+	/// <returns>True if the object was removed successfully.</returns>
+	public bool Remove(T obj, Bounds objBounds) {
+		if (!Encapsulates(bounds, objBounds)) {
 			return false;
 		}
-        return SubRemove(obj, objBounds);
-    }
+		return SubRemove(obj, objBounds);
+	}
 
 	/// <summary>
 	/// Check if the specified bounds intersect with anything in the tree. See also: GetColliding.
@@ -236,8 +244,7 @@ public class BoundsOctreeNode<T> {
 		children = childOctrees;
 	}
 
-	public Bounds GetBounds()
-	{
+	public Bounds GetBounds() {
 		return bounds;
 	}
 
@@ -459,14 +466,14 @@ public class BoundsOctreeNode<T> {
 		}
 	}
 
-    /// <summary>
-    /// Private counterpart to the public <see cref="Remove(T, Bounds)"/> method.
-    /// </summary>
-    /// <param name="obj">Object to remove.</param>
-    /// <param name="objBounds">3D bounding box around the object.</param>
-    /// <returns>True if the object was removed successfully.</returns>
-    bool SubRemove(T obj, Bounds objBounds) {
-        bool removed = false;
+	/// <summary>
+	/// Private counterpart to the public <see cref="Remove(T, Bounds)"/> method.
+	/// </summary>
+	/// <param name="obj">Object to remove.</param>
+	/// <param name="objBounds">3D bounding box around the object.</param>
+	/// <returns>True if the object was removed successfully.</returns>
+	bool SubRemove(T obj, Bounds objBounds) {
+		bool removed = false;
 
 		for (int i = 0; i < objects.Count; i++) {
 			if (objects[i].Obj.Equals(obj)) {
@@ -476,8 +483,8 @@ public class BoundsOctreeNode<T> {
 		}
 
 		if (!removed && children != null) {
-		    int bestFitChild = BestFitChild(objBounds);
-		    removed = children[bestFitChild].SubRemove(obj, objBounds);
+			int bestFitChild = BestFitChild(objBounds);
+			removed = children[bestFitChild].SubRemove(obj, objBounds);
 		}
 
 		if (removed && children != null) {
@@ -488,7 +495,7 @@ public class BoundsOctreeNode<T> {
 		}
 
 		return removed;
-    }
+	}
 
 	/// <summary>
 	/// Splits the octree into eight children.

--- a/Scripts/BoundsOctreeNode.cs
+++ b/Scripts/BoundsOctreeNode.cs
@@ -92,6 +92,19 @@ public class BoundsOctreeNode<T> {
 		return removed;
 	}
 
+    /// <summary>
+    /// Removes the specified object at the given position. Makes the assumption that the object only exists once in the tree.
+    /// </summary>
+    /// <param name="obj">Object to remove.</param>
+    /// <param name="objBounds">3D bounding box around the object.</param>
+    /// <returns>True if the object was removed successfully.</returns>
+    public bool Remove(T obj, Bounds objBounds) {
+        if (!Encapsulates(bounds, objBounds)) {
+			return false;
+		}
+        return SubRemove(obj, objBounds);
+    }
+
 	/// <summary>
 	/// Check if the specified bounds intersect with anything in the tree. See also: GetColliding.
 	/// </summary>
@@ -445,6 +458,37 @@ public class BoundsOctreeNode<T> {
 			}
 		}
 	}
+
+    /// <summary>
+    /// Private counterpart to the public <see cref="Remove(T, Bounds)"/> method.
+    /// </summary>
+    /// <param name="obj">Object to remove.</param>
+    /// <param name="objBounds">3D bounding box around the object.</param>
+    /// <returns>True if the object was removed successfully.</returns>
+    bool SubRemove(T obj, Bounds objBounds) {
+        bool removed = false;
+
+		for (int i = 0; i < objects.Count; i++) {
+			if (objects[i].Obj.Equals(obj)) {
+				removed = objects.Remove(objects[i]);
+				break;
+			}
+		}
+
+		if (!removed && children != null) {
+		    int bestFitChild = BestFitChild(objBounds);
+		    removed = children[bestFitChild].SubRemove(obj, objBounds);
+		}
+
+		if (removed && children != null) {
+			// Check if we should merge nodes now that we've removed an item
+			if (ShouldMerge()) {
+				Merge();
+			}
+		}
+
+		return removed;
+    }
 
 	/// <summary>
 	/// Splits the octree into eight children.

--- a/Scripts/PointOctree.cs
+++ b/Scripts/PointOctree.cs
@@ -79,6 +79,24 @@ public class PointOctree<T> where T : class {
 		return removed;
 	}
 
+    /// <summary>
+    /// Removes the specified object at the given position. Makes the assumption that the object only exists once in the tree.
+    /// </summary>
+    /// <param name="obj">Object to remove.</param>
+    /// <param name="objPos">Position of the object.</param>
+    /// <returns>True if the object was removed successfully.</returns>
+    public bool Remove(T obj, Vector3 objPos) {
+		bool removed = rootNode.Remove(obj, objPos);
+
+		// See if we can shrink the octree down now that we've removed the item
+		if (removed) {
+			Count--;
+			Shrink();
+		}
+
+		return removed;
+	}
+
 	/// <summary>
 	/// Returns objects that are within maxDistance of the specified ray.
 	/// If none returns false. Uses supplied list for results.

--- a/Scripts/PointOctree.cs
+++ b/Scripts/PointOctree.cs
@@ -127,11 +127,37 @@ public class PointOctree<T> where T : class {
 		return collidingWith.ToArray();
 	}
 
-	/// <summary>
-	/// Draws node boundaries visually for debugging.
-	/// Must be called from OnDrawGizmos externally. See also: DrawAllObjects.
-	/// </summary>
-	public void DrawAllBounds() {
+    /// <summary>
+    /// Return objects that are within <paramref name="maxDistance"/> of the specified position.
+    /// If none, returns an empty array (not null).
+    /// </summary>
+    /// <param name="position">The position. Passing as ref to improve performance since it won't have to be copied.</param>
+    /// <param name="maxDistance">Maximum distance from the ray to consider.</param>
+    /// <returns>Objects within range.</returns>
+    public T[] GetNearby(Vector3 position, float maxDistance)
+    {
+        List<T> collidingWith = new List<T>();
+        rootNode.GetNearby(ref position, ref maxDistance, collidingWith);
+        return collidingWith.ToArray();
+    }
+
+    /// <summary>
+    /// Return all objects in the tree.
+    /// If none, returns an empty array (not null).
+    /// </summary>
+    /// <returns>All objects.</returns>
+    public ICollection<T> GetAll()
+    {
+        List<T> objects = new List<T>(Count);
+        rootNode.GetAll(objects);
+        return objects;
+    }
+
+    /// <summary>
+    /// Draws node boundaries visually for debugging.
+    /// Must be called from OnDrawGizmos externally. See also: DrawAllObjects.
+    /// </summary>
+    public void DrawAllBounds() {
 		rootNode.DrawAllBounds();
 	}
 

--- a/Scripts/PointOctree.cs
+++ b/Scripts/PointOctree.cs
@@ -17,11 +17,13 @@ using UnityEngine;
 public class PointOctree<T> where T : class {
 	// The total amount of objects currently in the tree
 	public int Count { get; private set; }
-	
+
 	// Root node of the octree
 	PointOctreeNode<T> rootNode;
+
 	// Size that the octree was on creation
 	readonly float initialSize;
+
 	// Minimum side length that a node can be - essentially an alternative to having a max depth
 	readonly float minSize;
 
@@ -79,13 +81,13 @@ public class PointOctree<T> where T : class {
 		return removed;
 	}
 
-    /// <summary>
-    /// Removes the specified object at the given position. Makes the assumption that the object only exists once in the tree.
-    /// </summary>
-    /// <param name="obj">Object to remove.</param>
-    /// <param name="objPos">Position of the object.</param>
-    /// <returns>True if the object was removed successfully.</returns>
-    public bool Remove(T obj, Vector3 objPos) {
+	/// <summary>
+	/// Removes the specified object at the given position. Makes the assumption that the object only exists once in the tree.
+	/// </summary>
+	/// <param name="obj">Object to remove.</param>
+	/// <param name="objPos">Position of the object.</param>
+	/// <returns>True if the object was removed successfully.</returns>
+	public bool Remove(T obj, Vector3 objPos) {
 		bool removed = rootNode.Remove(obj, objPos);
 
 		// See if we can shrink the octree down now that we've removed the item
@@ -105,15 +107,14 @@ public class PointOctree<T> where T : class {
 	/// <param name="maxDistance">Maximum distance from the ray to consider</param>
 	/// <param name="nearBy">Pre-initialized list to populate</param>
 	/// <returns>True if items are found, false if not</returns>
-	public bool GetNearbyNonAlloc(Ray ray, float maxDistance, List<T> nearBy)
-	{
+	public bool GetNearbyNonAlloc(Ray ray, float maxDistance, List<T> nearBy) {
 		nearBy.Clear();
 		rootNode.GetNearby(ref ray, ref maxDistance, nearBy);
 		if (nearBy.Count > 0)
 			return true;
 		return false;
 	}
-	
+
 	/// <summary>
 	/// Return objects that are within maxDistance of the specified ray.
 	/// If none, returns an empty array (not null).
@@ -127,37 +128,35 @@ public class PointOctree<T> where T : class {
 		return collidingWith.ToArray();
 	}
 
-    /// <summary>
-    /// Return objects that are within <paramref name="maxDistance"/> of the specified position.
-    /// If none, returns an empty array (not null).
-    /// </summary>
-    /// <param name="position">The position. Passing as ref to improve performance since it won't have to be copied.</param>
-    /// <param name="maxDistance">Maximum distance from the ray to consider.</param>
-    /// <returns>Objects within range.</returns>
-    public T[] GetNearby(Vector3 position, float maxDistance)
-    {
-        List<T> collidingWith = new List<T>();
-        rootNode.GetNearby(ref position, ref maxDistance, collidingWith);
-        return collidingWith.ToArray();
-    }
+	/// <summary>
+	/// Return objects that are within <paramref name="maxDistance"/> of the specified position.
+	/// If none, returns an empty array (not null).
+	/// </summary>
+	/// <param name="position">The position. Passing as ref to improve performance since it won't have to be copied.</param>
+	/// <param name="maxDistance">Maximum distance from the ray to consider.</param>
+	/// <returns>Objects within range.</returns>
+	public T[] GetNearby(Vector3 position, float maxDistance) {
+		List<T> collidingWith = new List<T>();
+		rootNode.GetNearby(ref position, ref maxDistance, collidingWith);
+		return collidingWith.ToArray();
+	}
 
-    /// <summary>
-    /// Return all objects in the tree.
-    /// If none, returns an empty array (not null).
-    /// </summary>
-    /// <returns>All objects.</returns>
-    public ICollection<T> GetAll()
-    {
-        List<T> objects = new List<T>(Count);
-        rootNode.GetAll(objects);
-        return objects;
-    }
+	/// <summary>
+	/// Return all objects in the tree.
+	/// If none, returns an empty array (not null).
+	/// </summary>
+	/// <returns>All objects.</returns>
+	public ICollection<T> GetAll() {
+		List<T> objects = new List<T>(Count);
+		rootNode.GetAll(objects);
+		return objects;
+	}
 
-    /// <summary>
-    /// Draws node boundaries visually for debugging.
-    /// Must be called from OnDrawGizmos externally. See also: DrawAllObjects.
-    /// </summary>
-    public void DrawAllBounds() {
+	/// <summary>
+	/// Draws node boundaries visually for debugging.
+	/// Must be called from OnDrawGizmos externally. See also: DrawAllObjects.
+	/// </summary>
+	public void DrawAllBounds() {
 		rootNode.DrawAllBounds();
 	}
 

--- a/Scripts/PointOctreeNode.cs
+++ b/Scripts/PointOctreeNode.cs
@@ -7,22 +7,29 @@ using UnityEngine;
 public class PointOctreeNode<T> where T : class {
 	// Centre of this node
 	public Vector3 Center { get; private set; }
+
 	// Length of the sides of this node
 	public float SideLength { get; private set; }
 
 	// Minimum size for a node in this octree
 	float minSize;
+
 	// Bounding box that represents this node
 	Bounds bounds = default(Bounds);
+
 	// Objects in this node
 	readonly List<OctreeObject> objects = new List<OctreeObject>();
+
 	// Child nodes, if any
 	PointOctreeNode<T>[] children = null;
+
 	// bounds of potential children to this node. These are actual size (with looseness taken into account), not base size
 	Bounds[] childBounds;
+
 	// If there are already numObjectsAllowed in a node, we split it into children
 	// A generally good number seems to be something around 8-15
 	const int NUM_OBJECTS_ALLOWED = 8;
+
 	// For reverting the bounds size after temporary changes
 	Vector3 actualBoundsSize;
 
@@ -90,18 +97,18 @@ public class PointOctreeNode<T> where T : class {
 		return removed;
 	}
 
-    /// <summary>
-    /// Removes the specified object at the given position. Makes the assumption that the object only exists once in the tree.
-    /// </summary>
-    /// <param name="obj">Object to remove.</param>
-    /// <param name="objPos">Position of the object.</param>
-    /// <returns>True if the object was removed successfully.</returns>
-    public bool Remove(T obj, Vector3 objPos) {
-        if (!Encapsulates(bounds, objPos)) {
+	/// <summary>
+	/// Removes the specified object at the given position. Makes the assumption that the object only exists once in the tree.
+	/// </summary>
+	/// <param name="obj">Object to remove.</param>
+	/// <param name="objPos">Position of the object.</param>
+	/// <returns>True if the object was removed successfully.</returns>
+	public bool Remove(T obj, Vector3 objPos) {
+		if (!Encapsulates(bounds, objPos)) {
 			return false;
 		}
-        return SubRemove(obj, objPos);
-    }
+		return SubRemove(obj, objPos);
+	}
 
 	/// <summary>
 	/// Return objects that are within maxDistance of the specified ray.
@@ -136,69 +143,60 @@ public class PointOctreeNode<T> where T : class {
 		}
 	}
 
-    /// <summary>
-    /// Return objects that are within <paramref name="maxDistance"/> of the specified position.
-    /// </summary>
-    /// <param name="position">The position.</param>
-    /// <param name="maxDistance">Maximum distance from the position to consider.</param>
-    /// <param name="result">List result.</param>
-    /// <returns>Objects within range.</returns>
-    public void GetNearby(ref Vector3 position, ref float maxDistance, List<T> result)
-    {
-        // Does the node contain this position at all?
-        // Note: Expanding the bounds is not exactly the same as a real distance check, but it's fast.
-        // TODO: Does someone have a fast AND accurate formula to do this check?
-        bounds.Expand(new Vector3(maxDistance * 2, maxDistance * 2, maxDistance * 2));
-        bool contained = bounds.Contains(position);
-        bounds.size = actualBoundsSize;
-        if (!contained)
-        {
-            return;
-        }
+	/// <summary>
+	/// Return objects that are within <paramref name="maxDistance"/> of the specified position.
+	/// </summary>
+	/// <param name="position">The position.</param>
+	/// <param name="maxDistance">Maximum distance from the position to consider.</param>
+	/// <param name="result">List result.</param>
+	/// <returns>Objects within range.</returns>
+	public void GetNearby(ref Vector3 position, ref float maxDistance, List<T> result) {
+		// Does the node contain this position at all?
+		// Note: Expanding the bounds is not exactly the same as a real distance check, but it's fast.
+		// TODO: Does someone have a fast AND accurate formula to do this check?
+		bounds.Expand(new Vector3(maxDistance * 2, maxDistance * 2, maxDistance * 2));
+		bool contained = bounds.Contains(position);
+		bounds.size = actualBoundsSize;
+		if (!contained) {
+			return;
+		}
 
-        // Check against any objects in this node
-        for (int i = 0; i < objects.Count; i++)
-        {
-            if (Vector3.Distance(position, objects[i].Pos) <= maxDistance)
-            {
-                result.Add(objects[i].Obj);
-            }
-        }
+		// Check against any objects in this node
+		for (int i = 0; i < objects.Count; i++) {
+			if (Vector3.Distance(position, objects[i].Pos) <= maxDistance) {
+				result.Add(objects[i].Obj);
+			}
+		}
 
-        // Check children
-        if (children != null)
-        {
-            for (int i = 0; i < 8; i++)
-            {
-                children[i].GetNearby(ref position, ref maxDistance, result);
-            }
-        }
-    }
+		// Check children
+		if (children != null) {
+			for (int i = 0; i < 8; i++) {
+				children[i].GetNearby(ref position, ref maxDistance, result);
+			}
+		}
+	}
 
-    /// <summary>
-    /// Return all objects in the tree.
-    /// </summary>
-    /// <returns>All objects.</returns>
-    public void GetAll(List<T> result)
-    {
-        // add directly contained objects
-        result.AddRange(objects.Select(o => o.Obj));
+	/// <summary>
+	/// Return all objects in the tree.
+	/// </summary>
+	/// <returns>All objects.</returns>
+	public void GetAll(List<T> result) {
+		// add directly contained objects
+		result.AddRange(objects.Select(o => o.Obj));
 
-        // add children objects
-        if (children != null)
-        {
-            for (int i = 0; i < 8; i++)
-            {
-                children[i].GetAll(result);
-            }
-        }
-    }
+		// add children objects
+		if (children != null) {
+			for (int i = 0; i < 8; i++) {
+				children[i].GetAll(result);
+			}
+		}
+	}
 
-    /// <summary>
-    /// Set the 8 children of this octree.
-    /// </summary>
-    /// <param name="childOctrees">The 8 new child nodes.</param>
-    public void SetChildren(PointOctreeNode<T>[] childOctrees) {
+	/// <summary>
+	/// Set the 8 children of this octree.
+	/// </summary>
+	/// <param name="childOctrees">The 8 new child nodes.</param>
+	public void SetChildren(PointOctreeNode<T>[] childOctrees) {
 		if (childOctrees.Length != 8) {
 			Debug.LogError("Child octree array must be length 8. Was length: " + childOctrees.Length);
 			return;
@@ -399,14 +397,14 @@ public class PointOctreeNode<T> where T : class {
 		}
 	}
 
-    /// <summary>
-    /// Private counterpart to the public <see cref="Remove(T, Vector3)"/> method.
-    /// </summary>
-    /// <param name="obj">Object to remove.</param>
-    /// <param name="objPos">Position of the object.</param>
-    /// <returns>True if the object was removed successfully.</returns>
-    bool SubRemove(T obj, Vector3 objPos) {
-        bool removed = false;
+	/// <summary>
+	/// Private counterpart to the public <see cref="Remove(T, Vector3)"/> method.
+	/// </summary>
+	/// <param name="obj">Object to remove.</param>
+	/// <param name="objPos">Position of the object.</param>
+	/// <returns>True if the object was removed successfully.</returns>
+	bool SubRemove(T obj, Vector3 objPos) {
+		bool removed = false;
 
 		for (int i = 0; i < objects.Count; i++) {
 			if (objects[i].Obj.Equals(obj)) {
@@ -416,8 +414,8 @@ public class PointOctreeNode<T> where T : class {
 		}
 
 		if (!removed && children != null) {
-		    int bestFitChild = BestFitChild(objPos);
-		    removed = children[bestFitChild].SubRemove(obj, objPos);
+			int bestFitChild = BestFitChild(objPos);
+			removed = children[bestFitChild].SubRemove(obj, objPos);
 		}
 
 		if (removed && children != null) {
@@ -428,7 +426,7 @@ public class PointOctreeNode<T> where T : class {
 		}
 
 		return removed;
-    }
+	}
 
 	/// <summary>
 	/// Splits the octree into eight children.


### PR DESCRIPTION
**Modification 1:**
Added a `Remove(T, Vector3)` overload method to both octree implementations, which removes the specified object at the given position.  In cases when the position of the object to be deleted is known, calling this overload improves algorithmic performance from `O(n)` to `O(log8(n))` compared to `Remove(T)`.

**Modification 2:** 
Added `GetNearby(Vector3, float)` method overload to `PointOctree`, which returns objects that are within the specified distance of the given position.  Added `GetAll` method to `PointOctree` which returns all contained objects.






