### PR TITLE
improved search nearby positions + removed ref kword for float params

### DIFF
--- a/Scripts/PointOctree.cs
+++ b/Scripts/PointOctree.cs
@@ -109,7 +109,7 @@ public class PointOctree<T> where T : class {
 	/// <returns>True if items are found, false if not</returns>
 	public bool GetNearbyNonAlloc(Ray ray, float maxDistance, List<T> nearBy) {
 		nearBy.Clear();
-		rootNode.GetNearby(ref ray, ref maxDistance, nearBy);
+		rootNode.GetNearby(ref ray, maxDistance, nearBy);
 		if (nearBy.Count > 0)
 			return true;
 		return false;
@@ -124,7 +124,7 @@ public class PointOctree<T> where T : class {
 	/// <returns>Objects within range.</returns>
 	public T[] GetNearby(Ray ray, float maxDistance) {
 		List<T> collidingWith = new List<T>();
-		rootNode.GetNearby(ref ray, ref maxDistance, collidingWith);
+		rootNode.GetNearby(ref ray, maxDistance, collidingWith);
 		return collidingWith.ToArray();
 	}
 
@@ -137,7 +137,7 @@ public class PointOctree<T> where T : class {
 	/// <returns>Objects within range.</returns>
 	public T[] GetNearby(Vector3 position, float maxDistance) {
 		List<T> collidingWith = new List<T>();
-		rootNode.GetNearby(ref position, ref maxDistance, collidingWith);
+		rootNode.GetNearby(ref position, maxDistance, collidingWith);
 		return collidingWith.ToArray();
 	}
 

--- a/Scripts/PointOctreeNode.cs
+++ b/Scripts/PointOctreeNode.cs
@@ -117,7 +117,7 @@ public class PointOctreeNode<T> where T : class {
 	/// <param name="maxDistance">Maximum distance from the ray to consider.</param>
 	/// <param name="result">List result.</param>
 	/// <returns>Objects within range.</returns>
-	public void GetNearby(ref Ray ray, ref float maxDistance, List<T> result) {
+	public void GetNearby(ref Ray ray, float maxDistance, List<T> result) {
 		// Does the ray hit this node at all?
 		// Note: Expanding the bounds is not exactly the same as a real distance check, but it's fast.
 		// TODO: Does someone have a fast AND accurate formula to do this check?
@@ -138,7 +138,7 @@ public class PointOctreeNode<T> where T : class {
 		// Check children
 		if (children != null) {
 			for (int i = 0; i < 8; i++) {
-				children[i].GetNearby(ref ray, ref maxDistance, result);
+				children[i].GetNearby(ref ray, maxDistance, result);
 			}
 		}
 	}
@@ -150,20 +150,16 @@ public class PointOctreeNode<T> where T : class {
 	/// <param name="maxDistance">Maximum distance from the position to consider.</param>
 	/// <param name="result">List result.</param>
 	/// <returns>Objects within range.</returns>
-	public void GetNearby(ref Vector3 position, ref float maxDistance, List<T> result) {
-		// Does the node contain this position at all?
-		// Note: Expanding the bounds is not exactly the same as a real distance check, but it's fast.
-		// TODO: Does someone have a fast AND accurate formula to do this check?
-		bounds.Expand(new Vector3(maxDistance * 2, maxDistance * 2, maxDistance * 2));
-		bool contained = bounds.Contains(position);
-		bounds.size = actualBoundsSize;
-		if (!contained) {
-			return;
-		}
+	public void GetNearby(ref Vector3 position, float maxDistance, List<T> result) {
+        // Does the node intersects with the sphere of center = position and radius = maxDistance?
+        float sqrMaxDistance = maxDistance * maxDistance;
+        if ((bounds.ClosestPoint(position) - position).sqrMagnitude > sqrMaxDistance) {
+            return;
+        }
 
 		// Check against any objects in this node
 		for (int i = 0; i < objects.Count; i++) {
-			if (Vector3.Distance(position, objects[i].Pos) <= maxDistance) {
+			if ((position - objects[i].Pos).sqrMagnitude <= sqrMaxDistance) {
 				result.Add(objects[i].Obj);
 			}
 		}
@@ -171,7 +167,7 @@ public class PointOctreeNode<T> where T : class {
 		// Check children
 		if (children != null) {
 			for (int i = 0; i < 8; i++) {
-				children[i].GetNearby(ref position, ref maxDistance, result);
+				children[i].GetNearby(ref position, maxDistance, result);
 			}
 		}
 	}


### PR DESCRIPTION
Dear Nition,
Thank you for providing your octree implementation, it has been very useful.
I made a couple of small changes to the PointOctree that I though to make sense:

1. removed the ref keyword for float variables that are not modified in the methods they serve as parameters.
2. modified the test used to find if a given octree node is relevant in the GetNearby position method. This test seems to be at least 2 times faster than modifying the bounds. It is also more robust in rejecting nodes that cannot contain points within the search volume.
3. avoided taking the square root to compare distances.

The overall execution time of the GetNearby position method is around 30% shorter. 

I made a pull request in case you find it useful.
Best regards,
Henrique