### PR TITLE
Add camera frustum checks to get objects from BoundsOctree

### DIFF
--- a/Scripts/BoundsOctree.cs
+++ b/Scripts/BoundsOctree.cs
@@ -174,6 +174,14 @@ public class BoundsOctree<T> {
 		rootNode.GetColliding(ref checkRay, collidingWith, maxDistance);
 	}
 
+	public List<T> GetWithinFrustum(Camera cam) {
+		var planes = GeometryUtility.CalculateFrustumPlanes(cam);
+
+		var list = new List<T>();
+		rootNode.GetWithinFrustum(planes, list);
+		return list;
+	}
+
 	public Bounds GetMaxBounds() {
 		return rootNode.GetBounds();
 	}

--- a/Scripts/BoundsOctreeNode.cs
+++ b/Scripts/BoundsOctreeNode.cs
@@ -231,6 +231,27 @@ public class BoundsOctreeNode<T> {
 		}
 	}
 
+	public void GetWithinFrustum(Plane[] planes, List<T> result) {
+		// Is the input node inside the frustum?
+		if (!GeometryUtility.TestPlanesAABB(planes, bounds)) {
+			return;
+		}
+
+		// Check against any objects in this node
+		for (int i = 0; i < objects.Count; i++) {
+			if (GeometryUtility.TestPlanesAABB(planes, objects[i].Bounds)) {
+				result.Add(objects[i].Obj);
+			}
+		}
+
+		// Check children
+		if (children != null) {
+			for (int i = 0; i < 8; i++) {
+				children[i].GetWithinFrustum(planes, result);
+			}
+		}
+	}
+
 	/// <summary>
 	/// Set the 8 children of this octree.
 	/// </summary>


### PR DESCRIPTION
I added this little bit of code for my project and it ended up being fairly clean, using only Unity's standard implementation. I think this could be fairly useful for others too.