### PR TITLE
Allow to use value types as a type parameter for PointOctree

### DIFF
--- a/Scripts/PointOctree.cs
+++ b/Scripts/PointOctree.cs
@@ -14,7 +14,7 @@ using UnityEngine;
 // Originally written for my game Scraps (http://www.scrapsgame.com) but intended to be general-purpose.
 // Copyright 2014 Nition, BSD licence (see LICENCE file). http://nition.co
 // Unity-based, but could be adapted to work in pure C#
-public class PointOctree<T> where T : class {
+public class PointOctree<T> {
 	// The total amount of objects currently in the tree
 	public int Count { get; private set; }
 

--- a/Scripts/PointOctreeNode.cs
+++ b/Scripts/PointOctreeNode.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 // A node in a PointOctree
 // Copyright 2014 Nition, BSD licence (see LICENCE file). http://nition.co
-public class PointOctreeNode<T> where T : class {
+public class PointOctreeNode<T> {
 	// Centre of this node
 	public Vector3 Center { get; private set; }
 


### PR DESCRIPTION
I'm not sure about `BoundsOctree`, but for `PointOctree` value types seem to work. In my game, I'm pushing `Vector3`s to it.